### PR TITLE
[MRG] fix build actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: run workflow build
 on: push
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,4 +17,4 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip     # install pip
           python3 -m pip install snakemake         # ...and snakemake
-          - run: snakemake -j 1
+      - run: snakemake -j 1


### PR DESCRIPTION
This PR adds (well, technically, fixes) an action that runs a simple `snakemake -j 1`. The validity of output is not checked in any way, tho.