### PR TITLE
add logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ upload_json
 .snakemake
 __pycache__
 .DS_Store
+logs

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,4 @@ clean:
 	
 log:
 	for file in output_pieces*/*/; do  echo $$file; echo $$file >> logs/chunks.txt; find $$file -maxdepth 1 -name "*md" | wc -l >> logs/chunks.txt; done
+	for file in upload_json/*json; do echo $$file >> logs/aggregated.txt; grep -o '{"id":' $$file | wc -l >> logs/aggregated.txt; done

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,7 @@ upload:
 update: upload
 
 clean:
-	rm -fr output_pieces_* upload_json
+	rm -fr output_pieces_* upload_json logs/*txt
+	
+log:
+	for file in output_pieces*/*/; do  echo $$file; echo $$file >> logs/chunks.txt; find $$file -maxdepth 1 -name "*md" | wc -l >> logs/chunks.txt; done

--- a/scripts/aggregate-markdown-pieces.py
+++ b/scripts/aggregate-markdown-pieces.py
@@ -95,7 +95,7 @@ def main():
     print(F"Skipped {n_skipped} files for not ending in .json.", file=sys.stderr)
     print(f"Wrote {len(chunks)} chunks to {args.output_json}", file=sys.stderr)    
     
-    f = open("logs/aggregated.txt", "w")
+    f = open("logs/aggregated.txt", "w+")
     f.write(f"Aggregated {n_loaded} chunks of information for {len(chunks)} IDs  into {args.output_json}.\n")
     f.close()
     

--- a/scripts/aggregate-markdown-pieces.py
+++ b/scripts/aggregate-markdown-pieces.py
@@ -95,7 +95,7 @@ def main():
     print(F"Skipped {n_skipped} files for not ending in .json.", file=sys.stderr)
     print(f"Wrote {len(chunks)} chunks to {args.output_json}", file=sys.stderr)    
     
-    f = open("logs/aggregated.txt", "a")
+    f = open("logs/aggregated.txt", "a+")
     f.write(f"Aggregated {n_loaded} chunks of information for {len(chunks)} IDs  into {args.output_json}.\n")
     f.close()
     

--- a/scripts/aggregate-markdown-pieces.py
+++ b/scripts/aggregate-markdown-pieces.py
@@ -93,8 +93,12 @@ def main():
 
     print(f"Loaded {n_loaded} chunks total.", file=sys.stderr)
     print(F"Skipped {n_skipped} files for not ending in .json.", file=sys.stderr)
-    print(f"Wrote {len(chunks)} chunks to {args.output_json}", file=sys.stderr)
-
+    print(f"Wrote {len(chunks)} chunks to {args.output_json}", file=sys.stderr)    
+    
+    f = open("logs/aggregated.txt", "a")
+    f.write(f"Aggregated {n_loaded} chunks of information for {len(chunks)} IDs  into {args.output_json}.\n")
+    f.close()
+    
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/scripts/aggregate-markdown-pieces.py
+++ b/scripts/aggregate-markdown-pieces.py
@@ -94,10 +94,7 @@ def main():
     print(f"Loaded {n_loaded} chunks total.", file=sys.stderr)
     print(F"Skipped {n_skipped} files for not ending in .json.", file=sys.stderr)
     print(f"Wrote {len(chunks)} chunks to {args.output_json}", file=sys.stderr)    
-    
-    f = open("logs/aggregated.txt", "w+")
-    f.write(f"Aggregated {n_loaded} chunks of information for {len(chunks)} IDs  into {args.output_json}.\n")
-    f.close()
+    print(f"Aggregated {n_loaded} chunks of information for {len(chunks)} IDs  into {args.output_json}." , file=sys.stderr)
     
 
 if __name__ == '__main__':

--- a/scripts/aggregate-markdown-pieces.py
+++ b/scripts/aggregate-markdown-pieces.py
@@ -95,7 +95,7 @@ def main():
     print(F"Skipped {n_skipped} files for not ending in .json.", file=sys.stderr)
     print(f"Wrote {len(chunks)} chunks to {args.output_json}", file=sys.stderr)    
     
-    f = open("logs/aggregated.txt", "a+")
+    f = open("logs/aggregated.txt", "w")
     f.write(f"Aggregated {n_loaded} chunks of information for {len(chunks)} IDs  into {args.output_json}.\n")
     f.close()
     


### PR DESCRIPTION
this creates two files that report numbers can be for testing and reporting. 
these files are also added to make clean and .gitignore 

the results look like this:

**logs/aggregated.txt**
Aggregated 74416 chunks of information for 64147 IDs  into upload_json/protein.json.
Aggregated 62096 chunks of information for 45898 IDs  into upload_json/compound.json.
Aggregated 421 chunks of information for 353 IDs  into upload_json/anatomy.json.
Aggregated 138055 chunks of information for 19971 IDs  into upload_json/gene.json.
Aggregated 2831 chunks of information for 1872 IDs  into upload_json/disease.json.

**logs/chunks.txt**
output_pieces_anatomy/01-embl/
     353
output_pieces_anatomy/01-kg/
      18
output_pieces_anatomy/10-expression/
      50
output_pieces_compound/01-pubchem/
   20638
output_pieces_compound/02-glycan/
   33754
output_pieces_compound/03-kg/
    4102
output_pieces_compound/04-drugcentral/
    3602
output_pieces_disease/00-links/
    1872
output_pieces_disease/01-genes/
     479
output_pieces_disease/02-proteins/
     480
output_pieces_gene/00-alias/
   19829
output_pieces_gene/01-appyter/
   19971
output_pieces_gene/02-appyter-lincs-geo-reverse/
   19971
output_pieces_gene/03-kg/
   17647
output_pieces_gene/04-disease/
     752
output_pieces_gene/05-MetGene/
    1202
output_pieces_gene/10-expression/
   19352
output_pieces_gene/11-reverse-search/
   19971
output_pieces_gene/20-transcripts/
   19352
output_pieces_gene/70-ucsc/
       8
output_pieces_protein/00-refseq/
   64147
output_pieces_protein/01-disease/
   10269


